### PR TITLE
refactor: Transition from Async to Sync Requests using minreq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,16 @@ repository = "https://github.com/dongri/openai-api-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-reqwest = { version = "0.11", features = ["json"] }
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.97"
+[dependencies.serde]
+version = "1"
+features = ["derive"]
+default-features = false
+
+[dependencies.serde_json]
+version = "1"
+default-features = false
+
+[dependencies.minreq]
+version = "2"
+default-features = false
+features = ["https-rustls", "json-using-serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-api-rs"
-version = "0.1.15"
+version = "1.0.0"
 edition = "2021"
 authors = ["Dongri Jin <dongrify@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Check out the [docs.rs](https://docs.rs/openai-api-rs/).
 Cargo.toml
 ```toml
 [dependencies]
-openai-api-rs = "0.1"
+openai-api-rs = "1.0"
 ```
 
 ## Usage
@@ -56,7 +56,7 @@ let req = ChatCompletionRequest {
 
 ### Send request
 ```rust
-let result = client.completion(req).await?;
+let result = client.completion(req)?;
 println!("{:?}", result.choices[0].text);
 ```
 
@@ -66,8 +66,7 @@ use openai_api_rs::v1::api::Client;
 use openai_api_rs::v1::chat_completion::{self, ChatCompletionRequest};
 use std::env;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new(env::var("OPENAI_API_KEY").unwrap().to_string());
     let req = ChatCompletionRequest {
         model: chat_completion::GPT4.to_string(),
@@ -90,7 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         logit_bias: None,
         user: None,
     };
-    let result = client.chat_completion(req).await?;
+    let result = client.chat_completion(req)?;
     println!("{:?}", result.choices[0].message.content);
     Ok(())
 }

--- a/examples/chat_completion.rs
+++ b/examples/chat_completion.rs
@@ -2,8 +2,7 @@ use openai_api_rs::v1::api::Client;
 use openai_api_rs::v1::chat_completion::{self, ChatCompletionRequest};
 use std::env;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new(env::var("OPENAI_API_KEY").unwrap().to_string());
     let req = ChatCompletionRequest {
         model: chat_completion::GPT4.to_string(),
@@ -26,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         logit_bias: None,
         user: None,
     };
-    let result = client.chat_completion(req).await?;
+    let result = client.chat_completion(req)?;
     println!("{:?}", result.choices[0].message.content);
     Ok(())
 }

--- a/examples/completion.rs
+++ b/examples/completion.rs
@@ -2,8 +2,7 @@ use openai_api_rs::v1::api::Client;
 use openai_api_rs::v1::completion::{self, CompletionRequest};
 use std::env;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new(env::var("OPENAI_API_KEY").unwrap().to_string());
     let req = CompletionRequest {
         model: completion::GPT3_TEXT_DAVINCI_003.to_string(),
@@ -23,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         logit_bias: None,
         user: None,
     };
-    let result = client.completion(req).await?;
+    let result = client.completion(req)?;
     println!("{:}", result.choices[0].text);
 
     Ok(())

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -2,15 +2,14 @@ use openai_api_rs::v1::api::Client;
 use openai_api_rs::v1::embedding::EmbeddingRequest;
 use std::env;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new(env::var("OPENAI_API_KEY").unwrap().to_string());
     let req = EmbeddingRequest {
         model: "text-embedding-ada-002".to_string(),
         input: "story time".to_string(),
         user: Option::None,
     };
-    let result = client.embedding(req).await?;
+    let result = client.embedding(req)?;
     println!("{:?}", result.data);
 
     Ok(())

--- a/examples/function_call.rs
+++ b/examples/function_call.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::{env, vec};
 
-async fn get_coin_price(coin: &str) -> f64 {
+fn get_coin_price(coin: &str) -> f64 {
     let coin = coin.to_lowercase();
     match coin.as_str() {
         "btc" | "bitcoin" => 10000.0,
@@ -13,8 +13,7 @@ async fn get_coin_price(coin: &str) -> f64 {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new(env::var("OPENAI_API_KEY").unwrap().to_string());
 
     let mut properties = HashMap::new();
@@ -60,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         user: None,
     };
 
-    let result = client.chat_completion(req).await?;
+    let result = client.chat_completion(req)?;
 
     match result.choices[0].finish_reason {
         chat_completion::FinishReason::stop => {
@@ -82,7 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let c: Currency = serde_json::from_str(&arguments)?;
             let coin = c.coin;
             if name == "get_coin_price" {
-                let price = get_coin_price(&coin).await;
+                let price = get_coin_price(&coin);
                 println!("{} price: {}", coin, price);
             }
         }

--- a/examples/function_call_role.rs
+++ b/examples/function_call_role.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::{env, vec};
 
-async fn get_coin_price(coin: &str) -> f64 {
+fn get_coin_price(coin: &str) -> f64 {
     let coin = coin.to_lowercase();
     match coin.as_str() {
         "btc" | "bitcoin" => 10000.0,
@@ -13,8 +13,7 @@ async fn get_coin_price(coin: &str) -> f64 {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new(env::var("OPENAI_API_KEY").unwrap().to_string());
 
     let mut properties = HashMap::new();
@@ -60,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         user: None,
     };
 
-    let result = client.chat_completion(req).await?;
+    let result = client.chat_completion(req)?;
 
     match result.choices[0].finish_reason {
         chat_completion::FinishReason::stop => {
@@ -93,7 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     chat_completion::ChatCompletionMessage {
                         role: chat_completion::MessageRole::function,
                         content: {
-                            let price = get_coin_price(&coin).await;
+                            let price = get_coin_price(&coin);
                             format!("{{\"price\": {}}}", price)
                         },
                         name: Some(String::from("get_coin_price")),
@@ -113,7 +112,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 logit_bias: None,
                 user: None,
             };
-            let result = client.chat_completion(req).await?;
+            let result = client.chat_completion(req)?;
             println!("{:?}", result.choices[0].message.content);
         }
         chat_completion::FinishReason::content_filter => {


### PR DESCRIPTION
# !! BREAKING !! 

### PROPOSAL
This PR suggests a transition in the library's approach, shifting from asynchronous operations with `reqwest` and `tokio` to synchronous operations using `minreq@2`. This adjustment serves to reduce the library's size and enhance build times. Furthermore, this modification empowers simpler applications that may not require the complexities of a heavyweight asynchronous library like `tokio`.