### PR TITLE
Add "response_format" to allow for json_object responses in chat completions

### DIFF
--- a/src/v1/chat_completion.rs
+++ b/src/v1/chat_completion.rs
@@ -49,6 +49,8 @@ pub struct ChatCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<Vec<String>>,
@@ -75,6 +77,7 @@ impl ChatCompletionRequest {
             top_p: None,
             stream: None,
             n: None,
+            response_format: None,
             stop: None,
             max_tokens: None,
             presence_penalty: None,
@@ -92,6 +95,7 @@ impl_builder_methods!(
     temperature: f64,
     top_p: f64,
     n: i64,
+    response_format: String,
     stream: bool,
     stop: Vec<String>,
     max_tokens: i64,


### PR DESCRIPTION
OpenAI recently added a new `response_format` property to the request body for chat completions requests endpoint. See here: [https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format)

This allows "JSON mode" for models that allow it.

I've not looked at all the code in detail so it may not work, but is hopefully a starting point.