### PR TITLE
Switch to serde_json::Value for the response_format type

### DIFF
--- a/src/v1/chat_completion.rs
+++ b/src/v1/chat_completion.rs
@@ -1,5 +1,6 @@
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize, Serializer};
+use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::impl_builder_methods;
@@ -49,7 +50,7 @@ pub struct ChatCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_format: Option<String>,
+    pub response_format: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -95,7 +96,7 @@ impl_builder_methods!(
     temperature: f64,
     top_p: f64,
     n: i64,
-    response_format: String,
+    response_format: Value,
     stream: bool,
     stop: Vec<String>,
     max_tokens: i64,


### PR DESCRIPTION
Hi,

My earlier PR was done in a bit of haste and I hadn't realized `response_format` was expecting an object. I thought I was expecting a string. My apologies!

So, I've changed it to `Value` type and it's now much better. For example:

```rust
let response_format = json!({
    "type": "json_object",
});

let request = ChatCompletionRequest::new(model, prompt).response_format(response_format);
```

Tested this locally and in production and working.