### PR TITLE
Fix assistant api

### DIFF
--- a/examples/assistant.rs
+++ b/examples/assistant.rs
@@ -14,10 +14,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tools.insert("type".to_string(), "code_interpreter".to_string());
 
     let req = AssistantRequest::new(GPT4_1106_PREVIEW.to_string());
-    req.clone()
-        .description("this is a test assistant".to_string());
-    req.clone().instructions("You are a personal math tutor. When asked a question, write and run Python code to answer the question.".to_string());
-    req.clone().tools(vec![tools]);
+    let req = req.clone().description("this is a test assistant".to_string());
+    let req = req.clone().instructions("You are a personal math tutor. When asked a question, write and run Python code to answer the question.".to_string());
+    let req = req.clone().tools(vec![tools]);
+    println!("{:?}", req);
+    
     let result = client.create_assistant(req)?;
     println!("{:?}", result.id);
 

--- a/src/v1/assistant.rs
+++ b/src/v1/assistant.rs
@@ -56,7 +56,7 @@ pub struct AssistantObject {
     pub model: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
-    pub tools: Vec<String>,
+    pub tools: Vec<HashMap<String, String>>,
     pub file_ids: Vec<String>,
     pub metadata: HashMap<String, String>,
 }


### PR DESCRIPTION
Currently the example using Assistant API is failing because the clone of the req is not stored.
This caused the API to be OK because you were not creating the Assistant in the right way.

In the first commit i fixed the clone method assigning to a variable back, that will generate the right Assistant:

```
AssistantRequest { model: "gpt-4-1106-preview", name: None, description: Some("this is a test assistant"), instructions: Some("You are a personal math tutor. When asked a question, write and run Python code to answer the question."), tools: Some([{"type": "code_interpreter"}]), file_ids: None, metadata: None }
```

But doing so you will uncover another problem with the deserialization of the response in the `AssistantObject`.

>  Error: APIError { message: "invalid type: map, expected a string at line 10 column 4" }

The second commit fixes the Object assigning the right value.

BTW you can check the right creation of the assistant from the playground:

```
waiting...
waiting...
waiting...
waiting...
waiting...
waiting...
waiting...
assistant: "The solution to the equation \\(3x + 11 = 14\\) is \\(x = 1\\)." []
user: "`I need to solve the equation 3x + 11 = 14. Can you help me?" []
```

