### PR TITLE
Allow generating images with Dall-E-3

### DIFF
--- a/src/v1/common.rs
+++ b/src/v1/common.rs
@@ -41,3 +41,7 @@ pub const GPT4_32K_0613: &str = "gpt-4-32k-0613";
 // - legacy
 pub const GPT4_0314: &str = "gpt-4-0314";
 pub const GPT4_32K_0314: &str = "gpt-4-32k-0314";
+
+// https://platform.openai.com/docs/api-reference/images/object
+pub const DALL_E_2: &str = "dall-e-2";
+pub const DALL_E_3: &str = "dall-e-3";

--- a/src/v1/image.rs
+++ b/src/v1/image.rs
@@ -12,6 +12,8 @@ pub struct ImageData {
 pub struct ImageGenerationRequest {
     pub prompt: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub n: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<String>,
@@ -25,6 +27,7 @@ impl ImageGenerationRequest {
     pub fn new(prompt: String) -> Self {
         Self {
             prompt,
+            model: None,
             n: None,
             size: None,
             response_format: None,


### PR DESCRIPTION
This adds a `model` field to the image generation request to allow for the selection of Dall-E-3