### PR TITLE
Deprecate `functions` and add `tools`

### DIFF
--- a/src/v1/chat_completion.rs
+++ b/src/v1/chat_completion.rs
@@ -62,7 +62,7 @@ pub struct ChatCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub seed: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tools: Option<Tool>,
+    pub tools: Option<Vec<Tool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(serialize_with = "serialize_tool_choice")]
     pub tool_choice: Option<ToolChoiceType>,

--- a/src/v1/chat_completion.rs
+++ b/src/v1/chat_completion.rs
@@ -109,7 +109,7 @@ impl_builder_methods!(
     logit_bias: HashMap<String, i32>,
     user: String,
     seed: i64,
-    tools: Tool,
+    tools: Vec<Tool>,
     tool_choice: ToolChoiceType
 );
 

--- a/src/v1/chat_completion.rs
+++ b/src/v1/chat_completion.rs
@@ -18,9 +18,17 @@ pub struct ChatCompletionRequest {
     pub model: String,
     pub messages: Vec<ChatCompletionMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[deprecated(
+        since = "2.1.5",
+        note = "This field is deprecated. Use `tools` instead."
+    )]
     pub functions: Option<Vec<Function>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(serialize_with = "serialize_function_call")]
+    #[deprecated(
+        since = "2.1.5",
+        note = "This field is deprecated. Use `tool_choice` instead."
+    )]
     pub function_call: Option<FunctionCallType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,


### PR DESCRIPTION
Fixes #47

This PR deprecates the fields `functions` and `function_call`, which have been declared deprecated in the official OpenAI docs.

It also implements the replacement fields `tools` and `tool_choice`.

Notes:
- Upon examining the `Function` struct in `chat_completion`, I noticed that the `parameters` field is required, even though the [documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-functions) mentions it's optional. This should be changed in the next major version.