### PR TITLE
Add the `system_fingerprint` field to the chat completion response

### DIFF
--- a/src/v1/chat_completion.rs
+++ b/src/v1/chat_completion.rs
@@ -135,6 +135,7 @@ pub struct ChatCompletionResponse {
     pub model: String,
     pub choices: Vec<ChatCompletionChoice>,
     pub usage: common::Usage,
+    pub system_fingerprint: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Completes #50 by adding the corresponding `system_fingerprint` field to the response of the request with `seed`