### PR TITLE
Impl Default trait for JSONSchemaDefine

### DIFF
--- a/examples/function_call.rs
+++ b/examples/function_call.rs
@@ -23,10 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Box::new(chat_completion::JSONSchemaDefine {
             schema_type: Some(chat_completion::JSONSchemaType::String),
             description: Some("The cryptocurrency to get the price of".to_string()),
-            enum_values: None,
-            properties: None,
-            required: None,
-            items: None,
+            ..Default::default()
         }),
     );
 

--- a/examples/function_call_role.rs
+++ b/examples/function_call_role.rs
@@ -23,10 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Box::new(chat_completion::JSONSchemaDefine {
             schema_type: Some(chat_completion::JSONSchemaType::String),
             description: Some("The cryptocurrency to get the price of".to_string()),
-            enum_values: None,
-            properties: None,
-            required: None,
-            items: None,
+            ..Default::default()
         }),
     );
 

--- a/src/v1/chat_completion.rs
+++ b/src/v1/chat_completion.rs
@@ -197,6 +197,19 @@ pub struct JSONSchemaDefine {
     pub items: Option<Box<JSONSchemaDefine>>,
 }
 
+impl Default for JSONSchemaDefine {
+    fn default() -> Self {
+        Self {
+            schema_type: None,
+            description: None,
+            enum_values: None,
+            properties: None,
+            required: None,
+            items: None,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct FunctionParameters {
     #[serde(rename = "type")]


### PR DESCRIPTION
In most cases, only a few properties of `JSONSchemaDefine` are used, and it seems cumbersome to explicitly declare other properties. I have also made modifications to the code in the examples.

Before :
```rust
Box::new(chat_completion::JSONSchemaDefine {
    schema_type: Some(chat_completion::JSONSchemaType::Array),
    description: Some("...".to_string()),
    enum_values: None,
    properties: None,
    required: None,
    items: Some(Box::new(chat_completion::JSONSchemaDefine {
        schema_type: Some(chat_completion::JSONSchemaType::Number),
        description: Some("...".to_string()),
        enum_values: None,
        properties: None,
        required: None,
        items: None,
    })),
})
```
After :
```rust
Box::new(chat_completion::JSONSchemaDefine {
    schema_type: Some(chat_completion::JSONSchemaType::Array),
    description: Some("...".to_string()),
    ..Default::default()
    items: Some(Box::new(chat_completion::JSONSchemaDefine {
        schema_type: Some(chat_completion::JSONSchemaType::Number),
        description: Some("...".to_string()),
        ..Default::default()
    })),
})
```