### PR TITLE
fix: route all traffic through proxy

### DIFF
--- a/src/v1/api.rs
+++ b/src/v1/api.rs
@@ -118,7 +118,7 @@ impl OpenAIClient {
         };
 
         let client = if let Some(proxy) = &self.proxy {
-            client.proxy(reqwest::Proxy::http(proxy).unwrap())
+            client.proxy(reqwest::Proxy::all(proxy).unwrap())
         } else {
             client
         };


### PR DESCRIPTION
I found that if I pass socks5 string to the builder the proxy won't be used. I created a fork, tested with `reqwest::Proxy::all` and confirmed that `reqwest::Proxy::http` was the problem.