### PR TITLE
Fix for structured error message

### DIFF
--- a/src/v1/run.rs
+++ b/src/v1/run.rs
@@ -65,6 +65,12 @@ impl_builder_methods!(
     metadata: HashMap<String, String>
 );
 
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct LastError {
+    pub code: String,
+    pub message: String,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RunObject {
     pub id: String,
@@ -76,7 +82,7 @@ pub struct RunObject {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required_action: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_error: Option<String>,
+    pub last_error: Option<LastError>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -132,7 +138,7 @@ pub struct RunStepObject {
     pub status: String,
     pub step_details: HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_error: Option<String>,
+    pub last_error: Option<LastError>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This change introduces a structured error object for the response. Previously if there is an error such as hitting quota or running out of funds, the API will return an error message and parsing will fail because it is not a string. Now it will get properly deserialized into the "LastError" struct.