### PR TITLE
Add rustls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,15 @@ repository = "https://github.com/dongri/openai-api-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["default-tls"]
+rustls = ["reqwest/rustls-tls"]
+default-tls = ["reqwest/default-tls"]
+
 [dependencies.reqwest]
 version = "0.12"
-features = ["json", "multipart", "socks"]
+default-features = false
+features = ["charset", "http2", "json", "multipart", "socks"]
 
 [dependencies.tokio]
 version = "1"


### PR DESCRIPTION
This allows library to be used without adding native-tls to dependencies with:

```toml
openai-api-rs = { version = "^5.0", default-features = false, features = ["rustls"] }
```

Default usage without features is unaffected.