### PR TITLE
realtime server event: InputAudioBufferCommited previous_item_id may be None / null

### DIFF
--- a/src/realtime/server_event.rs
+++ b/src/realtime/server_event.rs
@@ -31,7 +31,7 @@ pub struct ConversationCreated {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct InputAudioBufferCommited {
     pub event_id: String,
-    pub previous_item_id: String,
+    pub previous_item_id: Option<String>,
     pub item_id: String,
 }
 


### PR DESCRIPTION
Just received this after waiting for the initial session.created event and sending some simple voice data to the realtime API:

raw WebSocket text message:

```json
{"type":"input_audio_buffer.committed","event_id":"event_AYHl1xBb8vTEssMAzp2V4","previous_item_id":null,"item_id":"item_AYHl0tPbVU5QTPDrrpoOd"}
```

So I guess it's safe to say that the null case  should be supported.
