### PR TITLE
Update types.rs

### DIFF
--- a/src/realtime/types.rs
+++ b/src/realtime/types.rs
@@ -30,11 +30,13 @@ pub struct Session {
 #[serde(rename_all = "lowercase")]
 pub enum RealtimeVoice {
     Alloy,
+    Ash,
+    Ballad,
+    Coral,
     Echo,
-    Fable,
-    Onyx,
-    Nova,
+    Sage,
     Shimmer,
+    Verse,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/realtime/types.rs
+++ b/src/realtime/types.rs
@@ -38,9 +38,9 @@ pub enum RealtimeVoice {
 pub enum AudioFormat {
     #[serde(rename = "pcm16")]
     PCM16,
-    #[serde(rename = "g711-ulaw")]
+    #[serde(rename = "g711_ulaw")]
     G711ULAW,
-    #[serde(rename = "g711-alaw")]
+    #[serde(rename = "g711_alaw")]
     G711ALAW,
 }
 

--- a/src/realtime/types.rs
+++ b/src/realtime/types.rs
@@ -30,8 +30,11 @@ pub struct Session {
 #[serde(rename_all = "lowercase")]
 pub enum RealtimeVoice {
     Alloy,
-    Shimmer,
     Echo,
+    Fable,
+    Onyx,
+    Nova,
+    Shimmer,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Fixes

message: "Invalid value: 'g711-ulaw'. Supported values are: 'pcm16', 'g711_ulaw', and 'g711_alaw'.", param: Some("session.input_audio_format"), event_id: None } }