### PR TITLE
ensure rustls is used when feature is activated

### DIFF
--- a/src/v1/api.rs
+++ b/src/v1/api.rs
@@ -136,6 +136,9 @@ impl OpenAIClient {
         let url = format!("{}/{}", self.api_endpoint, path);
         let client = Client::builder();
 
+        #[cfg(feature = "rustls")]
+        let client = client.use_rustls_tls();
+
         let client = if let Some(timeout) = self.timeout {
             client.timeout(std::time::Duration::from_secs(timeout))
         } else {

--- a/src/v1/chat_completion.rs
+++ b/src/v1/chat_completion.rs
@@ -243,7 +243,7 @@ pub struct ChatCompletionChoice {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ChatCompletionResponse {
-    pub id: String,
+    pub id: Option<String>,
     pub object: String,
     pub created: i64,
     pub model: String,


### PR DESCRIPTION
when using the "rustls" feature, the reqwest client didn't actually end up using it. apparently, you also need to add `use_rustls_tls()` to the client builder. this makes sure that endpoints that need http/2 requests (like the gemini one) actually work 👍 

https://github.com/seanmonstar/reqwest/discussions/2350#discussioncomment-10020959