### PR TITLE
make "id" an optional field on ChatCompletionResponse

### DIFF
--- a/src/v1/chat_completion.rs
+++ b/src/v1/chat_completion.rs
@@ -243,7 +243,7 @@ pub struct ChatCompletionChoice {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ChatCompletionResponse {
-    pub id: String,
+    pub id: Option<String>,
     pub object: String,
     pub created: i64,
     pub model: String,


### PR DESCRIPTION
some openai-compatible APIs don't necessarily send the id field, is this okay to do?