### PR TITLE
ensure rustls is used when feature is activated

### DIFF
--- a/src/v1/api.rs
+++ b/src/v1/api.rs
@@ -136,6 +136,9 @@ impl OpenAIClient {
         let url = format!("{}/{}", self.api_endpoint, path);
         let client = Client::builder();
 
+        #[cfg(feature = "rustls")]
+        let client = client.use_rustls_tls();
+
         let client = if let Some(timeout) = self.timeout {
             client.timeout(std::time::Duration::from_secs(timeout))
         } else {


### PR DESCRIPTION
when using the "rustls" feature, the reqwest client didn't actually end up using it. apparently, you also need to add `use_rustls_tls()` to the client builder. this makes sure that endpoints that need http/2 requests (like the gemini one) actually work 👍 

https://github.com/seanmonstar/reqwest/discussions/2350#discussioncomment-10020959

also sorry for uploading this twice im incredibly sleep deprived