### PR TITLE
- Update FailedError struct to correct api schema

### DIFF
--- a/src/realtime/types.rs
+++ b/src/realtime/types.rs
@@ -234,8 +234,9 @@ pub enum ResponseStatusDetail {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct FailedError {
-    pub code: String,
-    pub message: String,
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub r#type: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
The Failederror struct has the following format from OpenAI

```
{
    "error":{
        "code":null,
        "message":"The server had an error while processing your request. Sorry about that! Please contact us through our help center at help.openai.com if the error persists. (include session ID in your message: sess_BPCNZdLMHo8ERhJi0qgtq). We recommend you retry your request.",
        "type":"server_error"
    },
    "type":"failed"
}
```

Updated struct to match

https://platform.openai.com/docs/api-reference/realtime-server-events/response/done