### PR TITLE
Do not serialize any AudioTranscription property if its null.

### DIFF
--- a/src/realtime/types.rs
+++ b/src/realtime/types.rs
@@ -51,8 +51,11 @@ pub enum AudioFormat {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AudioTranscription {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
 }
 


### PR DESCRIPTION
Open api does not accept `null` for realtime Session.input_audio_transcription properties. So if the type for one of those properties is `None` it should not be serialized and added  to the json.