### PR TITLE
Make object field in openai-compatible response optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "openai-api-rs-prime"
+name = "openai-api-rs"
 version = "7.0.1"
 edition = "2021"
 authors = ["Dongri Jin <dongrium@gmail.com>"]
 license = "MIT"
 description = "OpenAI API client library for Rust (unofficial)"
-repository = "https://github.com/MoonKraken/openai-api-rs"
+repository = "https://github.com/dongri/openai-api-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
(this is a remake of #189 which will be closed because I used the wrong branch)

So the zAI API claims to be compatible with the OpenAI chat completion API, but for whatever reason it does not include an "object" field in the response. In its current state openai-api-rs requires this field to be present, so it was breaking when using zAI APIs.

This change makes the field optional, allowing the lib to successfully deserialize responses from zAI.